### PR TITLE
add interface and mock

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,15 +1,21 @@
 module github.com/northvolt/kinesis-producer
 
-go 1.16
+go 1.17
 
 require (
 	github.com/aws/aws-sdk-go v1.21.10
 	github.com/golang/protobuf v1.3.2
 	github.com/jpillora/backoff v0.0.0-20180909062703-3050d21c67d7
-	github.com/pkg/errors v0.8.1 // indirect
 	github.com/sirupsen/logrus v1.4.2
+	go.uber.org/zap v1.10.0
+)
+
+require (
+	github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af // indirect
+	github.com/konsorten/go-windows-terminal-sequences v1.0.1 // indirect
+	github.com/pkg/errors v0.8.1 // indirect
 	go.uber.org/atomic v1.4.0 // indirect
 	go.uber.org/multierr v1.1.0 // indirect
-	go.uber.org/zap v1.10.0
 	golang.org/x/net v0.0.0-20190724013045-ca1201d0de80 // indirect
+	golang.org/x/sys v0.0.0-20190422165155-953cdadca894 // indirect
 )

--- a/loggers/kplogrus/logrus.go
+++ b/loggers/kplogrus/logrus.go
@@ -1,7 +1,7 @@
 package kplogrus
 
 import (
-	producer "github.com/a8m/kinesis-producer"
+	producer "github.com/northvolt/kinesis-producer"
 	"github.com/sirupsen/logrus"
 )
 

--- a/loggers/kpzap/zap.go
+++ b/loggers/kpzap/zap.go
@@ -3,7 +3,7 @@ package kpzap
 import (
 	"go.uber.org/zap"
 
-	producer "github.com/a8m/kinesis-producer"
+	producer "github.com/northvolt/kinesis-producer"
 )
 
 // Logger implements a zap.Logger logger for kinesis-producer

--- a/produceriface/produceriface.go
+++ b/produceriface/produceriface.go
@@ -1,0 +1,49 @@
+package produceriface
+
+type Producer interface {
+	Put([]byte, string) error
+}
+
+type Mock struct {
+	putCh chan put
+}
+
+func NewMock() *Mock {
+	return &Mock{
+		putCh: make(chan put),
+	}
+}
+
+func (mock *Mock) DrainReads() {
+	go func() {
+		for {
+			_, _, reply := mock.ExpectRead()
+			reply(nil)
+		}
+	}()
+}
+
+type putArgs struct {
+	message   []byte
+	partition string
+}
+
+type put struct {
+	req      putArgs
+	replyErr chan<- error
+}
+
+func (mock *Mock) Put(message []byte, partition string) error {
+	replyErr := make(chan error)
+
+	mock.putCh <- put{
+		req:      putArgs{message, partition},
+		replyErr: replyErr,
+	}
+	return <-replyErr
+}
+
+func (mock *Mock) ExpectRead() ([]byte, string, func(error)) {
+	put := <-mock.putCh
+	return put.req.message, put.req.partition, func(e error) { put.replyErr <- e }
+}


### PR DESCRIPTION
The commit basically migrate what @DVasselli has implemented in `firefly-mappers`, but I thought it would make more sense to put it here. 

1. add interface and mock directly in the repo
2. avoid deep mocking into `producer.Producer.Config.Client` as `producer.Putter`